### PR TITLE
12 compatibility with python 311

### DIFF
--- a/dev_tests/dev_test.py
+++ b/dev_tests/dev_test.py
@@ -6,19 +6,19 @@ import sys
 sys.path.insert(0, '..')
 
 import numjuggler
-print numjuggler.__file__
+print(numjuggler.__file__)
 
 # test Range
 from numjuggler.numbering import Range
-print Range(1, 5)
-print Range(1)
-print Range(5, 1)
-print 5 in Range(1, 3), 5 in Range(5)
-print Range(), Range() == (0, -1)
+print(Range(1, 5))
+print(Range(1))
+print(Range(5, 1))
+print(5 in Range(1, 3), 5 in Range(5))
+print(Range(), Range() == (0, -1))
 
 
 # test reading of map file
 import numjuggler.numbering
 d1, d2 = numjuggler.numbering.read_map_file('map_file.txt')
-print d1
-print d2
+print(d1)
+print(d2)

--- a/dev_tests/itab.sh
+++ b/dev_tests/itab.sh
@@ -2,7 +2,7 @@
 
 # Will tab be printed as tab?
 echo -e -"\t"- > itab.out
-python -c 'print "=\t="' >> itab.out
+python -c 'print("=\t=")' >> itab.out
 
 # --preservetabs flag. The --debug flag turns off the use of dump file (which can also affect the tabs. BTW why?
 numjuggler -s 10 itab_ --debug                > itab_.tabsno

--- a/numjuggler/utils/resource.py
+++ b/numjuggler/utils/resource.py
@@ -1,4 +1,3 @@
-import pkg_resources as pkg
 import inspect
 
 # noinspection PyCompatibility
@@ -6,36 +5,3 @@ try:
     from pathlib import Path
 except:
     from pathlib2 import Path
-
-
-def filename_resolver(package=None):
-    if package is None:
-        caller_package = inspect.getmodule(inspect.stack()[1][0]).__name__
-        package = caller_package
-
-    resource_manager = pkg.ResourceManager()
-
-    def func(resource):
-        return resource_manager.resource_filename(package, resource)
-
-    # noinspection PyCompatibility
-    func.__doc__ = "Computes file names for resources located in {}".format(package)
-
-    return func
-
-
-def path_resolver(package=None):
-
-    resolver = filename_resolver(package)
-
-    def func(resource):
-        filename = resolver(resource)
-        return Path(filename)
-
-    if package is None:
-        package = "caller package"
-
-    # noinspection PyCompatibility
-    func.__doc__ = "Computes Path for resources located in {}".format(package)
-
-    return func

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Utilities',
     ],
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,6 @@ import six
 from numjuggler.utils.io import cd_temporarily
 from numjuggler.main import main
 
-# test_data_path = path_resolver('tests')('data')
 test_data_path = Path('./data')
 assert test_data_path.exists(), "Cannot access test data files"
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, nested_scopes
 
+from pathlib import Path
+
 import pytest
 import six
-from numjuggler.utils.resource import path_resolver
 from numjuggler.utils.io import cd_temporarily
 from numjuggler.main import main
 
-test_data_path = path_resolver('tests')('data')
+# test_data_path = path_resolver('tests')('data')
+test_data_path = Path('./data')
 assert test_data_path.exists(), "Cannot access test data files"
 
 
@@ -46,5 +48,3 @@ def test_test_main(tmpdir, capsys, inp, command, expected):
     actual_numbers = load_line_heading_numbers(out.split('\n'))
     expected_numbers = list(f for f in map(int, expected.split()))
     assert expected_numbers == actual_numbers, "Output of numjuggler is wrong"
-
-


### PR DESCRIPTION
This pull request fixes issue #12 (copied from inr-kit/numjuggler#20)

Currently travis-CI is not running on this repository. The `travis_run_all.sh`  script started locally shows no errors.

@dodu94: can you please check whether this branch solves the issue before I merge the changes into main?