### PR TITLE
Support the presence of VOL cards in cells definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ htmlcov/
 # Travis tests
 travis_tests/*.diff
 travis_tests/*.res
+
+# vs code
+settings.json

--- a/numjuggler/parser.py
+++ b/numjuggler/parser.py
@@ -876,6 +876,14 @@ def _split_cell(input_, self):
             inpt_parm = inpt_parm.replace(vs, tp, 1)
             vals.append((vv, vt))
             fmts.append(vf)
+        elif s.lower() == 'vol':
+            vs = t.pop(0)
+            vv = vs  # we do not want to touch this, leave it as a string
+            vf = fmt_d(vs)
+            vt = 'vol'
+            inpt_parm = inpt_parm.replace(vs, tp, 1)
+            vals.append((vv, vt))
+            fmts.append(vf)
         elif 'fill' in s.lower():
             # print '_split_cell: has fill!'
             # assume that only one integer follows the fill keyword, optionally

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,18 @@
+from numjuggler.parser import Card
+
+
+class TestCardParser:
+    def test_vol_param(self):
+        definition = [
+            "600177 400 -1.00000e+00 $ WATER_LEFT\n",
+            "          600003 -600421 601230 -600013 600011\n",
+            "           Vol=1.335972e+01\n",
+            "           imp:n=1.0   imp:p=1.0   U=5972  \n",
+        ]
+
+        cell2 = Card(definition, ctype=3, pos=1)
+        cell2.get_values()
+
+        cell2._set_value_by_type("u", 30)
+        assert "U=30" in cell2.card()
+        assert "Vol=1.335972e+01" in cell2.card()


### PR DESCRIPTION
Hello, thanks for numjuggler, we really rely on this package at [F4E](https://github.com/Fusion4Energy)

We encountered a bug rather particular. Essentially, when trying to change a universe value in cells we found out that only for some numbers the substitution would not work. This is a minimal example that reproduce the behaviour:

```python
from numjuggler.parser import Card
definition = [
    '600177 400 -1.00000e+00 $ WATER_LEFT\n',
    '          600003 -600421 601230 -600013 600011\n',
    '           Vol=1.335972e+01\n',
    '           imp:n=1.0   imp:p=1.0   U=5972  \n']

cell2 = Card(definition, ctype=3, pos=1)
cell2.get_values()
print(cell2.card())
cell2._set_value_by_type("u", 30)
print(cell2.card())

print(cell2.input[-1])
```
```python
600177 400 -1.00000e+00 $ WATER_LEFT
          600003 -600421 601230 -600013 600011
           Vol=1.335972e+01
           imp:n=1.0   imp:p=1.0   U=5972  

600177 400 -1.00000e+00 $ WATER_LEFT
          600003 -600421 601230 -600013 600011
           Vol=1.3330  e+01
           imp:n=1.0   imp:p=1.0   U=5972  

           imp:n=~   imp:p=~   U=5972
```

As you may notice, the number 30 is substituted in the volume card instead of the U= card.

Indeed, if one was to print the input of the card, this is what would come out:
```python
Cell input:
['{:<6} {:<3} ~{} ', '          {:<6} -{:<6} {:<6} -{:<6} {:<6}', '           {}Vol=1.33{:<4}e+01', '           imp:n=~   imp:p=~   U=5972  ']
```

After a bit of investigation I located the problem to be in the ``parser._split_cell()`` method. Essentially, the VOL card was not supported and if one was unlucky enough that the number of the universe is contained inside the volume value, the replace method would act on the the VOL= card string instead of on the U= one. Bear in mind that for universe numbers that are low (1,2,3..) this may happen a lot.

I propose with this PR a fix for this, let me know what you think. I also added a small test to prove the efficacy of it.